### PR TITLE
fix(package.json): updating aurelia dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "typings": "^1.3.0"
   },
   "dependencies": {
-    "aurelia-webpack-plugin": "^1.0.0-beta.4.0.1",
+    "aurelia-webpack-plugin": "^1.0.0",
     "bundle-loader": "^0.5.4"
   },
   "peerDependencies": {


### PR DESCRIPTION
Aurelia Webpack Plugin has hit a stable 1.0 release, so this plugin should use the latest version with numerous fixes for scoped packages and more.
